### PR TITLE
Adjust Redis info command

### DIFF
--- a/redis/Redis.php
+++ b/redis/Redis.php
@@ -2132,7 +2132,7 @@ class Redis
      * - vm_enabled
      * - role
      * @link    https://redis.io/commands/info
-     * @return string
+     * @return string|array
      * @example
      * <pre>
      * $redis->info();


### PR DESCRIPTION
Info doc bock says

Returns an associative array of strings and integers, with the following keys

but does return string.

It should be string|array